### PR TITLE
場所検索機能修正 #87

### DIFF
--- a/app/assets/stylesheets/autocomplete.scss
+++ b/app/assets/stylesheets/autocomplete.scss
@@ -1,5 +1,6 @@
 #autocomplete-list {
   background-color: white;
+  color: #0259b7;
   border: 1px solid #ccc;
   overflow-y: auto;
   width: 90%;
@@ -20,7 +21,7 @@
 
 /* オートコンプリートのアイテムがホバーされた時のスタイル */
 .autocomplete-item:hover {
-  background-color: #f0f0f0;
+  text-decoration: underline;
 }
 
 /* オートコンプリートリストの最後のアイテムの境界線を除去 */

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -112,7 +112,7 @@ const RamenMap = {
 
   // マーカーを作成してマップに追加する
   createMarker: function(place, map) {
-    new google.maps.Marker({
+    const marker = new google.maps.Marker({
       position: place.geometry.location,
       map: map,
       title: place.name,
@@ -120,6 +120,16 @@ const RamenMap = {
         url: ramenIconPath, // ラーメン店の独自アイコン
         scaledSize: new google.maps.Size(40, 40)
       }
+    });
+  
+    // 店舗名をクリックした際に遷移するリンクを含む InfoWindow を作成
+    const infoWindow = new google.maps.InfoWindow({
+      content: `<div><strong><a href="/ramen_shops/${place.place_id}">${place.name}</a></strong><br>${place.vicinity || ''}</div>` // 店舗名や住所を表示
+    });
+  
+    // マーカーがクリックされた時に InfoWindow を表示
+    marker.addListener('click', function() {
+      infoWindow.open(map, marker);
     });
   },
 
@@ -231,26 +241,23 @@ document.addEventListener("turbo:load", function() {
   const searchInput = document.getElementById("search-keyword");
   const autocompleteList = document.getElementById("autocomplete-list");
 
-  // オートコンプリート候補を表示する関数
   searchInput.addEventListener("input", function() {
     const keyword = this.value;
-    const searchType = document.querySelector('input[name="search_type"]').value; // search_typeを取得
+    const searchType = document.querySelector('input[name="search_type"]').value;
 
-    // キーワードが一定以上の長さの場合のみオートコンプリートを行う
     if (keyword.length > 1) {
       fetch(`/ramen_shops/autocomplete?search_type=${searchType}&keyword=${keyword}`)
         .then(response => response.json())
         .then(data => {
-          autocompleteList.innerHTML = ''; // リストをクリア
+          autocompleteList.innerHTML = '';
           data.forEach(item => {
             const listItem = document.createElement("li");
             listItem.textContent = item.name;
             listItem.classList.add("autocomplete-item");
-            
-            // リストアイテムをクリックした際に、フォームに反映する
+
             listItem.addEventListener("click", function() {
-              searchInput.value = item.name; // 候補を検索フィールドに設定
-              autocompleteList.innerHTML = ''; // リストをクリア
+              searchInput.value = item.name;
+              autocompleteList.innerHTML = '';
             });
 
             autocompleteList.appendChild(listItem);
@@ -258,14 +265,13 @@ document.addEventListener("turbo:load", function() {
         })
         .catch(error => console.error('Error:', error));
     } else {
-      autocompleteList.innerHTML = ''; // 検索キーワードが短い場合はリストをクリア
+      autocompleteList.innerHTML = '';
     }
   });
 
-  // フォーカスが外れた場合にオートコンプリートリストをクリア
   searchInput.addEventListener("blur", function() {
     setTimeout(function() {
-      autocompleteList.innerHTML = ''; // リストをクリア
-    }, 200); // setTimeoutの時間を少し長めにしてクリックイベントを処理
+      autocompleteList.innerHTML = '';
+    }, 200);
   });
 });

--- a/app/views/ramen_shops/index.html.erb
+++ b/app/views/ramen_shops/index.html.erb
@@ -37,7 +37,7 @@
                         search_type: params[:search_type],
                         location: params[:location]) %>
               </strong><br>
-              <span><%= shop.vicinity || shop.formatted_address %></span>
+              <span><%= shop.address %></span>
             <% end %>
           </li>
           </div>

--- a/lib/tasks/update_ramen_shops.rake
+++ b/lib/tasks/update_ramen_shops.rake
@@ -1,0 +1,32 @@
+namespace :update_ramen_shops do
+  desc "ラーメン店情報をRamenShopsテーブルに保存"
+  task fetch_data: :environment do
+    location = { lat: 35.6762, lng: 139.6503 }  # 東京の座標（例）
+    keyword = ENV['KEYWORD'] || 'ラーメン'
+
+    service = GooglePlacesService.new(ENV['GOOGLE_PLACES_API_KEY'])
+
+    # search_by_location_with_spots を使って検索
+    ramen_shops = service.search_by_location_with_spots(keyword, location)
+
+    ramen_shops.each do |shop_data|
+      # shop_data の中身を確認するために出力
+      puts "Shop data: #{shop_data.inspect}"
+
+      # save_ramen_shop_data メソッドを使用してRamenShopを保存
+      begin
+        ramen_shop = service.save_ramen_shop_data(shop_data.place_id)
+
+        if ramen_shop.persisted?
+          puts "Saved or found existing ramen shop: #{ramen_shop.name}"
+        else
+          puts "Failed to save ramen shop: #{ramen_shop.errors.full_messages.join(', ')}"
+        end
+      rescue => e
+        puts "Error saving ramen shop: #{e.message}"
+      end
+    end
+
+    puts "Finished updating ramen shops data."
+  end
+end


### PR DESCRIPTION
- 店舗検索機能をRamenShopsテーブルから検索するように変更
- ラーメン店情報をデータベースに保存するrakeタスクを追加
- マップのラーメン店アイコンをクリックしたら、ラーメン店名が表示され、クリックすると店舗詳細ページに遷移できるように修正