### PR TITLE
コメントのカウントを非同期化 #102

### DIFF
--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -78,6 +78,7 @@
 
 .comment-content {
   flex-grow: 1; /* コンテンツ部分をできるだけ広げる */
+  margin-top: 5px;
 }
 
 .comment-actions {

--- a/app/assets/stylesheets/videos.scss
+++ b/app/assets/stylesheets/videos.scss
@@ -268,6 +268,9 @@
   color: #333;
 }
 
+.fa-comment {
+  margin-bottom: 3px;
+}
 .action-link {
   color: inherit;
   text-decoration: none;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,7 +18,7 @@ class CommentsController < ApplicationController
     @comment = @video.comments.find(params[:id])
     @comment.destroy
     flash[:alert] = t('flash.comments.destroy_success')
-    redirect_to videos_path, status: :see_other
+    redirect_to request.referer || videos_path, status: :see_other
   end
 
   private

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -6,3 +6,9 @@
     <%= form.submit t('.create'), class: 'submit-button' %>
   <% end %>
 <% end %>
+
+<%= turbo_stream.replace "comment-count-#{@video.id}" do %>
+  <div class="comment-count">
+    <%= @video.comments.count %>
+  </div>
+<% end %>

--- a/app/views/videos/_video_details.html.erb
+++ b/app/views/videos/_video_details.html.erb
@@ -3,11 +3,13 @@
     <%= image_tag video.user.avatar.url, alt: video.user.name, class: "avatar-image" %>
     <div class="actions">
       <%= render 'videos/like_button', video: video %>
-      <div class='comment-icon'>
-      <i class="fa fa-comment" data-video-id="<%= video.id %>"></i>
-        <div class="comment-count">
-          <%= video.comments.count %>
-        </div>
+      <div class="comment-icon">
+        <i class="fa fa-comment" data-video-id="<%= video.id %>"></i>
+        <%= turbo_frame_tag "comment-count-#{video.id}" do %>
+          <div class="comment-count">
+            <%= video.comments.count %>
+          </div>
+        <% end %>
       </div>
       <%= render 'comments/comments', video: video %>
     </div>


### PR DESCRIPTION
- コメントのカウント機能もturbo_streamを使用して非同期化処理を実装
- コメント削除した後のリダイレクト先を、videos_pathではなく、request.refererに変更