### PR TITLE
オートログイン #119

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
   def new; end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember_me])
 
     if @user
       flash[:notice] = t('flash.sessions.login_success')

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,8 +14,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user)
       flash[:notice] = t('flash.users.create_success')
-      redirect_to login_path
+      redirect_to videos_path
     else
       flash[:error] = t('flash.users.create_failure')
       render :new, status: :unprocessable_entity

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -12,6 +12,10 @@
             <%= f.label :password, class: "form-label" %>
             <%= f.password_field :password, class: "form-control" %>
           </div>
+          <div class="mb-3">
+            <%= f.label :remember_me, class: "form-label" %>
+            <%= f.check_box :remember_me %>
+          </div>
           <%= f.submit t('.login'), class: "btn-primary" %>
         <% end %>
     

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -319,7 +319,7 @@ Rails.application.config.sorcery.configure do |config|
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
     #
-    # user.remember_me_for =
+    user.remember_me_for = 1.month
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -13,7 +13,7 @@ ja:
       login_failure: "メールアドレスまたはパスワードが違います。"
       logout: "ログアウトしました。"
     users:
-      create_success: "ユーザー登録に成功しました。"
+      create_success: "ユーザー登録が完了し、ログインしました。"
       create_failure: "ユーザー登録に失敗しました。"
       update_success: "プロフィールを編集しました。"
       update_failure: "プロフィール編集に失敗しました。"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
     label:
       email: メールアドレス
       password: パスワード
+      remember_me: 次回以降自動でログイン
   sessions:
     new:
       title: ログイン

--- a/db/migrate/20241007070504_add_remember_me_to_users.rb
+++ b/db/migrate/20241007070504_add_remember_me_to_users.rb
@@ -1,0 +1,7 @@
+class AddRememberMeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :remember_me_token, :string
+    add_column :users, :remember_me_token_expires_at, :datetime
+    add_index :users, :remember_me_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_16_021655) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_07_070504) do
   create_table "comments", charset: "utf8mb4", force: :cascade do |t|
     t.text "content", null: false
     t.bigint "user_id", null: false
@@ -61,7 +61,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_16_021655) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 


### PR DESCRIPTION
- sorceryのremember_me機能を追加
- ログイン画面でリメンバーミーチャックボックスを設定して、チェックを入れた場合はクッキーを保存して1ヶ月間ログイン状態を保持するように設定
- サインアップ時に自動でログインされるように、sorceryのauto_loginメソッドを使用して修正
- usersテーブルにremember_me_tokenカラムとremember_me_token_expires_atカラムを追加