### PR TITLE
アップロードした動画のURL表示方法を修正 #123

### DIFF
--- a/app/views/videos/edit.html.erb
+++ b/app/views/videos/edit.html.erb
@@ -50,7 +50,7 @@
 
       <% if @video.file.present? %>
         <div class="current-video-url">
-          <p><%= t('.current_video_url') %><%= link_to @video.file.url, @video.file.url, target: "_blank" %></p>
+          <p><%= t('.current_video') %><%= link_to 'こちら', @video.file.url, target: "_blank" %></p>
         </div>
       <% end %>
     </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -56,7 +56,7 @@ ja:
       price_message: 金額を入力してください
       tag_message: "カンマ区切りで入力してください(例: 新宿,醤油ラーメン)"
       create: 編集
-      current_video_url: "現在の動画URL:"
+      current_video: "現在の動画は"
       file_message: "※現在の動画から変更する場合のみ選択してください"
   ramen_shops:
     search_form:


### PR DESCRIPTION
- 投稿動画の編集画面の既存動画の表示方法をURLから「現在の動画はこちら」リンクに修正