### PR TITLE
データベース設定修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     ports:
-      - 3307:3306
+      - 3306:3306
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s


### PR DESCRIPTION
- CIのRspecテスト実行時にコンテナが起動しない問題が発生したため、database.ymlを確認し、dbコンテナのportを修正