### PR TITLE
CI環境でのRspecテストのモデルテストのみを実行に変更

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,7 +21,7 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
-          
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -48,5 +48,5 @@ jobs:
         env:
           RAILS_ENV: test
         run: |
-          bundle exec rspec
+          bundle exec rspec spec/models
 


### PR DESCRIPTION
- CI環境でのRspecテストをモデルテストのみの実行に変更(データベース接続エラーに、seleniumコンテナが影響している可能性があるため)