### PR TITLE
データベースの文字コード修正

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
-  create_table "authentications", charset: "latin1", force: :cascade do |t|
+  create_table "authentications", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "provider", null: false
     t.string "uid", null: false
@@ -21,8 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
     t.index ["user_id"], name: "index_authentications_on_user_id"
   end
 
-  create_table "comments", charset: "latin1", force: :cascade do |t|
-    t.text "content", null: false
+  create_table "comments", charset: "utf8mb4", force: :cascade do |t|
+    t.text "content", size: :medium, null: false
     t.bigint "user_id", null: false
     t.bigint "video_id", null: false
     t.datetime "created_at", null: false
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
     t.index ["video_id"], name: "index_comments_on_video_id"
   end
 
-  create_table "likes", charset: "latin1", force: :cascade do |t|
+  create_table "likes", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "video_id", null: false
     t.datetime "created_at", null: false
@@ -40,26 +40,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
     t.index ["video_id"], name: "index_likes_on_video_id"
   end
 
-  create_table "ramen_shops", charset: "latin1", force: :cascade do |t|
+  create_table "ramen_shops", charset: "utf8mb4", force: :cascade do |t|
     t.string "place_id", null: false
     t.string "name"
     t.string "address"
     t.float "latitude"
     t.float "longitude"
     t.string "phone_number"
-    t.text "opening_hours"
+    t.text "opening_hours", size: :medium
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "tags", charset: "latin1", force: :cascade do |t|
+  create_table "tags", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "users", charset: "latin1", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"
@@ -78,7 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
-  create_table "video_tags", charset: "latin1", force: :cascade do |t|
+  create_table "video_tags", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "video_id", null: false
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
@@ -87,7 +87,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
     t.index ["video_id"], name: "index_video_tags_on_video_id"
   end
 
-  create_table "videos", charset: "latin1", force: :cascade do |t|
+  create_table "videos", charset: "utf8mb4", force: :cascade do |t|
     t.string "menu_name"
     t.integer "price"
     t.string "file"
@@ -95,7 +95,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_10_132650) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "ramen_shop_id"
-    t.text "comment"
+    t.text "comment", size: :medium
     t.string "place_id"
     t.index ["ramen_shop_id"], name: "fk_rails_0a063615c2"
     t.index ["user_id"], name: "index_videos_on_user_id"


### PR DESCRIPTION
- データベースの文字コードが変わってしまったため、すべてのテーブルの文字コードをutf8mb4に修正